### PR TITLE
chain: add lru block cache to bitcoind client

### DIFF
--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -145,7 +145,7 @@ func (c *BitcoindClient) GetBlockHeight(hash *chainhash.Hash) (int32, error) {
 
 // GetBlock returns a block from the hash.
 func (c *BitcoindClient) GetBlock(hash *chainhash.Hash) (*wire.MsgBlock, error) {
-	return c.chainConn.client.GetBlock(hash)
+	return c.chainConn.getBlock(hash)
 }
 
 // GetBlockVerbose returns a verbose block from the hash.

--- a/chain/block_cache.go
+++ b/chain/block_cache.go
@@ -1,0 +1,55 @@
+package chain
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/neutrino/cache"
+	"github.com/lightninglabs/neutrino/cache/lru"
+)
+
+// blockCache holds a LRU cache along with a getBlockImpl function to be used
+// to fetch new blocks if they are not found in the cache.
+type blockCache struct {
+	cache *lru.Cache
+}
+
+// getBlock checks the blockCache LRU cache to see if the block for the
+// associated hash is already there and returns it if it is. If it is not then
+// the blockCache's getBlockImpl function is used to fetch the block.
+// The new block is then stored in the cache and the LFU block is evicted if
+// the cache is at maximum capacity.
+func (b *blockCache) getBlock(hash *chainhash.Hash,
+	fetchNewBlock func(hash *chainhash.Hash) (*wire.MsgBlock,
+		error)) (*wire.MsgBlock, error) {
+
+	var block *wire.MsgBlock
+
+	// Check if the block corresponding to the given hash is already
+	// stored in the blockCache and return it if it is.
+	cacheBlock, err := b.cache.Get(*hash)
+	if err != nil && err != cache.ErrElementNotFound {
+		return nil, err
+	}
+	if cacheBlock != nil {
+		return cacheBlock.(*cache.CacheableBlock).MsgBlock(), nil
+	}
+
+	// Fetch the block from the chain backends.
+	block, err = fetchNewBlock(hash)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add the new block to blockCache. If the cache is at its maximum
+	// capacity then the LFU item will be evicted in favour of this new
+	// block.
+	_, err = b.cache.Put(*hash, &cache.CacheableBlock{
+		Block: btcutil.NewBlock(block),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return block, nil
+}

--- a/chain/block_cache_test.go
+++ b/chain/block_cache_test.go
@@ -1,0 +1,141 @@
+package chain
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/neutrino/cache"
+	"github.com/lightninglabs/neutrino/cache/lru"
+	"github.com/stretchr/testify/require"
+)
+
+type mockChainBackend struct {
+	blocks         map[chainhash.Hash]*wire.MsgBlock
+	chainCallCount int
+
+	sync.RWMutex
+}
+
+func (m *mockChainBackend) addBlock(block *wire.MsgBlock, nonce uint32) {
+	m.Lock()
+	block.Header.Nonce = nonce
+	hash := block.Header.BlockHash()
+	m.blocks[hash] = block
+	m.Unlock()
+}
+func (m *mockChainBackend) GetBlock(blockHash *chainhash.Hash) (*wire.MsgBlock, error) {
+	m.RLock()
+	defer m.RUnlock()
+	m.chainCallCount++
+
+	block, ok := m.blocks[*blockHash]
+	if !ok {
+		return nil, fmt.Errorf("block not found")
+	}
+
+	return block, nil
+}
+
+func newMockChain() *mockChainBackend {
+	return &mockChainBackend{
+		blocks: make(map[chainhash.Hash]*wire.MsgBlock),
+	}
+}
+
+func (m *mockChainBackend) resetChainCallCount() {
+	m.RLock()
+	defer m.RUnlock()
+
+	m.chainCallCount = 0
+}
+
+// TestBlockCacheGetBlock tests that the block cache works correctly as a LFU block
+// cache for the given max capacity.
+func TestBlockCacheGetBlock(t *testing.T) {
+	mc := newMockChain()
+	getBlockImpl := mc.GetBlock
+
+	block1 := &wire.MsgBlock{Header: wire.BlockHeader{Nonce: 1}}
+	block2 := &wire.MsgBlock{Header: wire.BlockHeader{Nonce: 2}}
+	block3 := &wire.MsgBlock{Header: wire.BlockHeader{Nonce: 3}}
+
+	// Determine the size of one of the blocks.
+	sz, _ := (&cache.CacheableBlock{Block: btcutil.NewBlock(block1)}).Size()
+
+	// A new cache is set up with a capacity of 2 blocks
+	bc := blockCache{
+		cache: lru.NewCache(2 * sz),
+	}
+
+	blockhash1 := block1.BlockHash()
+	blockhash2 := block2.BlockHash()
+	blockhash3 := block3.BlockHash()
+
+	mc.addBlock(&wire.MsgBlock{}, 1)
+	mc.addBlock(&wire.MsgBlock{}, 2)
+	mc.addBlock(&wire.MsgBlock{}, 3)
+
+	// We expect the initial cache to be empty
+	require.Equal(t, 0, bc.cache.Len())
+
+	// After calling getBlock for block1, it is expected that the cache
+	// will have a size of 1 and will contain block1. One chain backends
+	// call is expected to fetch the block.
+	_, err := bc.getBlock(&blockhash1, getBlockImpl)
+	require.NoError(t, err)
+	require.Equal(t, 1, bc.cache.Len())
+	require.Equal(t, 1, mc.chainCallCount)
+	mc.resetChainCallCount()
+
+	_, err = bc.cache.Get(blockhash1)
+	require.NoError(t, err)
+
+	// After calling getBlock for block2, it is expected that the cache
+	// will have a size of 2 and will contain both block1 and block2.
+	// One chain backends call is expected to fetch the block.
+	_, err = bc.getBlock(&blockhash2, getBlockImpl)
+	require.NoError(t, err)
+	require.Equal(t, 2, bc.cache.Len())
+	require.Equal(t, 1, mc.chainCallCount)
+	mc.resetChainCallCount()
+
+	_, err = bc.cache.Get(blockhash1)
+	require.NoError(t, err)
+
+	_, err = bc.cache.Get(blockhash2)
+	require.NoError(t, err)
+
+	// getBlock is called again for block1 to make block2 the LFU block.
+	// No call to the chain backend is expected since block 1 is already
+	// in the cache.
+	_, err = bc.getBlock(&blockhash1, getBlockImpl)
+	require.NoError(t, err)
+	require.Equal(t, 2, bc.cache.Len())
+	require.Equal(t, 0, mc.chainCallCount)
+	mc.resetChainCallCount()
+
+	// Since the cache is now at its max capacity, it is expected that when
+	// getBlock is called for a new block then the LFU block will be
+	// evicted. It is expected that block2 will be evicted. After calling
+	// Getblock for block3, it is expected that the cache will have a
+	// length of 2 and will contain block 1 and 3.
+	_, err = bc.getBlock(&blockhash3, getBlockImpl)
+	require.NoError(t, err)
+	require.Equal(t, 2, bc.cache.Len())
+	require.Equal(t, 1, mc.chainCallCount)
+	mc.resetChainCallCount()
+
+	_, err = bc.cache.Get(blockhash1)
+	require.NoError(t, err)
+
+	_, err = bc.cache.Get(blockhash2)
+	require.True(t, errors.Is(err, cache.ErrElementNotFound))
+
+	_, err = bc.cache.Get(blockhash3)
+	require.NoError(t, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/kkdai/bstream v0.0.0-20181106074824-b3251f7901ec // indirect
 	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf
 	github.com/lightninglabs/neutrino v0.11.0
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67
 	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006
 	google.golang.org/genproto v0.0.0-20190201180003-4b09977fb922 // indirect


### PR DESCRIPTION
This commit adds a LRU block cache to the BitcoindConn in order to
save on some bandwidth consumption. The blockcache is then shared amongst all the BitcoindClients.